### PR TITLE
Feature/player model

### DIFF
--- a/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
+++ b/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		E2FE912D25BF537F007D3B97 /* BISItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE912C25BF537F007D3B97 /* BISItemView.swift */; };
 		E2FE913225BF58E2007D3B97 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913125BF58E2007D3B97 /* Player.swift */; };
 		E2FE913725BF5ABF007D3B97 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913625BF5ABF007D3B97 /* Enums.swift */; };
+		E2FE913C25BF62D8007D3B97 /* TalentTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913B25BF62D8007D3B97 /* TalentTree.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -98,6 +99,7 @@
 		E2FE912C25BF537F007D3B97 /* BISItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BISItemView.swift; sourceTree = "<group>"; };
 		E2FE913125BF58E2007D3B97 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		E2FE913625BF5ABF007D3B97 /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
+		E2FE913B25BF62D8007D3B97 /* TalentTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalentTree.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +223,7 @@
 			isa = PBXGroup;
 			children = (
 				E2FE913125BF58E2007D3B97 /* Player.swift */,
+				E2FE913B25BF62D8007D3B97 /* TalentTree.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				E2FE908025BF4782007D3B97 /* SceneDelegate.swift in Sources */,
 				E2FE910E25BF52FE007D3B97 /* SelectLegendaryView.swift in Sources */,
 				E2FE90E925BF50FA007D3B97 /* UsedLegendaryViewController.swift in Sources */,
+				E2FE913C25BF62D8007D3B97 /* TalentTree.swift in Sources */,
 				E2FE90D525BF508A007D3B97 /* SelectStyleViewController.swift in Sources */,
 				E2FE90E425BF50EC007D3B97 /* UsedSoulbindViewController.swift in Sources */,
 				E2FE90DA25BF50A4007D3B97 /* BISOverviewViewController.swift in Sources */,

--- a/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
+++ b/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
@@ -182,12 +182,12 @@
 		E2FE90B725BF48E4007D3B97 /* Other */ = {
 			isa = PBXGroup;
 			children = (
+				E2FE913625BF5ABF007D3B97 /* Enums.swift */,
 				E2FE90B025BF485A007D3B97 /* WoWTankSim.entitlements */,
 				E2FE907D25BF4782007D3B97 /* AppDelegate.swift */,
 				E2FE907F25BF4782007D3B97 /* SceneDelegate.swift */,
 				E2FE908625BF4783007D3B97 /* Assets.xcassets */,
 				E2FE908B25BF4783007D3B97 /* Info.plist */,
-				E2FE913625BF5ABF007D3B97 /* Enums.swift */,
 			);
 			path = Other;
 			sourceTree = "<group>";

--- a/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
+++ b/WoWTankSim/WoWTankSim.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		E2FE913225BF58E2007D3B97 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913125BF58E2007D3B97 /* Player.swift */; };
 		E2FE913725BF5ABF007D3B97 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913625BF5ABF007D3B97 /* Enums.swift */; };
 		E2FE913C25BF62D8007D3B97 /* TalentTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE913B25BF62D8007D3B97 /* TalentTree.swift */; };
+		E2FE914225BF6E34007D3B97 /* Pelagos.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE914125BF6E34007D3B97 /* Pelagos.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +101,7 @@
 		E2FE913125BF58E2007D3B97 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		E2FE913625BF5ABF007D3B97 /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		E2FE913B25BF62D8007D3B97 /* TalentTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalentTree.swift; sourceTree = "<group>"; };
+		E2FE914125BF6E34007D3B97 /* Pelagos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pelagos.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -222,6 +224,7 @@
 		E2FE90BA25BF495C007D3B97 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				E2FE914025BF6E24007D3B97 /* Soulbinds */,
 				E2FE913125BF58E2007D3B97 /* Player.swift */,
 				E2FE913B25BF62D8007D3B97 /* TalentTree.swift */,
 			);
@@ -251,6 +254,14 @@
 				E2FE912C25BF537F007D3B97 /* BISItemView.swift */,
 			);
 			path = ResultViews;
+			sourceTree = "<group>";
+		};
+		E2FE914025BF6E24007D3B97 /* Soulbinds */ = {
+			isa = PBXGroup;
+			children = (
+				E2FE914125BF6E34007D3B97 /* Pelagos.swift */,
+			);
+			path = Soulbinds;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -384,6 +395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2FE90FF25BF52CF007D3B97 /* SelectGearSourceView.swift in Sources */,
+				E2FE914225BF6E34007D3B97 /* Pelagos.swift in Sources */,
 				E2FE90D025BF506C007D3B97 /* SelectLegendaryViewController.swift in Sources */,
 				E2FE908225BF4782007D3B97 /* ViewController.swift in Sources */,
 				E2FE911925BF533D007D3B97 /* BISOverviewView.swift in Sources */,

--- a/WoWTankSim/WoWTankSim/Model/Player.swift
+++ b/WoWTankSim/WoWTankSim/Model/Player.swift
@@ -11,6 +11,7 @@ struct Player {
     var spec: Spec
     var source: [Source]
     var talents: TalentTree
-    var soulbind: Soulbind
-
+    var soulbind: Soulbind //Need to finish setting up soulbind/conduit information when I get to that screen
+    var legendary: String //Need to update to Legendary enum or protocol
+    var Style: Int //Int representing the percent offensive. Might need to be updates when adapting the app to other roles
 }

--- a/WoWTankSim/WoWTankSim/Model/Player.swift
+++ b/WoWTankSim/WoWTankSim/Model/Player.swift
@@ -1,0 +1,16 @@
+//
+//  Player.swift
+//  WoWTankSim
+//
+//  Created by Christopher Devito on 1/25/21.
+//
+
+import Foundation
+
+struct Player {
+    var spec: Spec
+    var source: [Source]
+    var talents: TalentTree
+    var soulbind: Soulbind
+
+}

--- a/WoWTankSim/WoWTankSim/Model/Soulbinds/Pelagos.swift
+++ b/WoWTankSim/WoWTankSim/Model/Soulbinds/Pelagos.swift
@@ -1,0 +1,13 @@
+//
+//  Pelagos.swift
+//  WoWTankSim
+//
+//  Created by Christopher Devito on 1/25/21.
+//
+
+import Foundation
+
+struct Pelagos {
+    let row1 = "Combat Meditation"
+    var row2 = "Conduit"
+}

--- a/WoWTankSim/WoWTankSim/Model/TalentTree.swift
+++ b/WoWTankSim/WoWTankSim/Model/TalentTree.swift
@@ -1,0 +1,25 @@
+//
+//  TalentTree.swift
+//  WoWTankSim
+//
+//  Created by Christopher Devito on 1/25/21.
+//
+
+import Foundation
+
+struct TalentTree {
+    var fifteen: Int, twentyFive: Int, thirty: Int, thirtyFive: Int
+    var forty: Int, fortyFive: Int, fifty: Int
+
+    init(fifteen: Int, twentyFive: Int, thirty: Int, thirtyFive: Int,
+         forty: Int, fortyFive: Int, fifty: Int) {
+        self.fifteen = (fifteen >= 1 && fifteen <= 3) ? fifteen : 1
+        self.twentyFive = (twentyFive >= 1 && twentyFive <= 3) ? twentyFive : 1
+        self.thirty = (thirty >= 1 && thirty <= 3) ? thirty : 1
+        self.thirtyFive = (thirtyFive >= 1 && thirtyFive <= 3) ? thirtyFive : 1
+        self.forty = (forty >= 1 && forty <= 3) ? forty : 1
+        self.fortyFive = (fortyFive >= 1 && fortyFive <= 3) ? fortyFive : 1
+        self.fifty = (fifty >= 1 && fifty <= 3) ? fifty : 1
+    }
+
+}

--- a/WoWTankSim/WoWTankSim/Other/Enums.swift
+++ b/WoWTankSim/WoWTankSim/Other/Enums.swift
@@ -21,8 +21,33 @@ enum Source {
 }
 
 enum Soulbind {
-    case Kyrian
-    case NightFae
-    case Venthyr
-    case Necrolord
+    case Kyrian(KyrianSoulbind)
+    case NightFae(NightFaeSoulbind)
+    case Venthyr(VenthyrSoulbind)
+    case Necrolord(NecrolordSoulbind)
+
+    enum KyrianSoulbind {
+        case Pelagos
+        case Kleia
+        case Mikanikos
+    }
+
+    enum NightFaeSoulbind {
+        case Niya
+        case Dreamweaver
+        case Korayn
+    }
+
+    enum VenthyrSoulbind {
+        case Nadjia
+        case Theotar
+        case Draven
+    }
+
+    enum NecrolordSoulbind {
+        case Marileth
+        case Emeni
+        case Heirmir
+    }
 }
+

--- a/WoWTankSim/WoWTankSim/Other/Enums.swift
+++ b/WoWTankSim/WoWTankSim/Other/Enums.swift
@@ -19,3 +19,10 @@ enum Source {
     case DungeonMythicPlus(Int)
     case PVPHonor, PVPConquest, Crafted, BOE
 }
+
+enum Soulbind {
+    case Kyrian
+    case NightFae
+    case Venthyr
+    case Necrolord
+}


### PR DESCRIPTION
Adds a player model and related enums and structs to support the model. 

This model will be used to keep track of the setup information when going through the selections portion of the app and to show the talents, soulbinds, and legendary that were used in the results portion of the app. 